### PR TITLE
Python 2.6 support

### DIFF
--- a/fisher_jenks/test_fj.py
+++ b/fisher_jenks/test_fj.py
@@ -1,6 +1,7 @@
-from fj_refactored import fisher_jenks
-import numpy
+import sys
 import time
+import numpy
+from fj_refactored import fisher_jenks
 
 cores = [1,2,4,16,32]
 classes = [5,6,7]
@@ -15,6 +16,9 @@ for c in cores:
                 #wrapped in try since we will blow out RAM at some point
                 classification = fisher_jenks(data, k, c)
                 t2 = time.time()
-                print "Processed {} data points in {} classes using {} cores.  Total time: {}".format(d, k, c, t2-t1)
+                print "Processed {0} data points in {1} classes using {2} cores. Total time: {3}".format(d, k, c, t2-t1)
+            except KeyboardInterrupt:
+                print "Aborting"
+                sys.exit(1)
             except:
-                print "FAILURE: {} Data Points.".format(d)
+                print "FAILURE: {0} data points.".format(d)

--- a/weights/_contW_binning_par.py
+++ b/weights/_contW_binning_par.py
@@ -327,7 +327,7 @@ if __name__ == "__main__":
     for job in jobs:
         job.join()
     t5 = time.time()
-    print "MP using Process: {}".format(t5-t4)
+    print "MP using Process: {0}".format(t5-t4)
     
     print c.w == mdict
     

--- a/weights/contiguity_apply_async.py
+++ b/weights/contiguity_apply_async.py
@@ -29,7 +29,7 @@ def pcheck_joina(polygon_ids, weight_type='ROOK'):
                 edgeCache[polyId] = iEdges
             nbrs = potential_neighbors[polyId]
             if polyId not in w:
-                w[polyId] = []           
+                w[polyId] = []
             for j in nbrs:
                 join = False
                 if j not in edgeCache:
@@ -50,7 +50,7 @@ def pcheck_joina(polygon_ids, weight_type='ROOK'):
                         d.append(j)
                         w[polyId] = d
                         if j not in w:
-                            w[j] = []                       
+                            w[j] = []
                         k = w[j]
                         k.append(polyId)
                         w[j] = k
@@ -58,16 +58,14 @@ def pcheck_joina(polygon_ids, weight_type='ROOK'):
         return w
     else:
         print 'unsupported weight type'
-        return None     
+        return None
 
-
-def async_apply_w_callback(res,cores): 
-    
+def async_apply_w_callback(res,cores):
     ddict = defaultdict(set)
     def callback_dict(w):
         for key, value in w.items():
             for v in value:
-                ddict[key].add(v)     
+                ddict[key].add(v)
     
     t1 = time.time()
     #cores = mp.cpu_count()
@@ -77,8 +75,8 @@ def async_apply_w_callback(res,cores):
     n = len(res['shapes'])
     starts = range(0,n,n/cores)
     ends = starts[1:]
-    ends.append(n)        
-    offsets = [ range(z[0],z[1]) for z in zip(starts, ends) ] 
+    ends.append(n)
+    offsets = [ range(z[0],z[1]) for z in zip(starts, ends) ]
 
     for offset in offsets:
         pool.apply_async(pcheck_joina, args=(offset,), callback=callback_dict)
@@ -90,19 +88,18 @@ def async_apply_w_callback(res,cores):
     return (t2 - t1)
 
 if __name__ == "__main__":
-
     cores = int(sys.argv[1])
-    print "This version uses apply_async with a callback function and {} cores.".format(cores)
+    print "This version uses apply_async with a callback function and {0} cores.".format(cores)
     
     fnames = ['1024_lattice.shp', '10000_lattice.shp', '50176_lattice.shp', '100489_lattice.shp', '1000_poly.shp', '10000_poly.shp', '50000_poly.shp', '100000_poly.shp']
     
     for fname in fnames:
         res = bin_shapefile('TestData/'+fname)
         global shapes
-        global potential_neighbors 
+        global potential_neighbors
         shapes = res['shapes']
-        potential_neighbors = res['potential_neighbors']   
+        potential_neighbors = res['potential_neighbors']
         
         t = async_apply_w_callback(res,cores)
         
-        print "{} required {} seconds.".format(fname, t)
+        print "{0} required {1} seconds.".format(fname, t)

--- a/weights/contiguity_joinable_queue.py
+++ b/weights/contiguity_joinable_queue.py
@@ -35,7 +35,7 @@ def pcheck_joins2(q,resultq, weight_type='ROOK'):
                     edgeCache[polyId] = iEdges
                 nbrs = potential_neighbors[polyId]
                 if polyId not in mdict:
-                    mdict[polyId] = []           
+                    mdict[polyId] = []
                 for j in nbrs:
                     join = False
                     if j not in edgeCache:
@@ -56,7 +56,7 @@ def pcheck_joins2(q,resultq, weight_type='ROOK'):
                             d.append(j)
                             mdict[polyId] = d
                             if j not in mdict:
-                                mdict[j] = []                       
+                                mdict[j] = []
                             k = mdict[j]
                             k.append(polyId)
                             mdict[j] = k
@@ -64,9 +64,8 @@ def pcheck_joins2(q,resultq, weight_type='ROOK'):
         #Put the resultant dict back into the queue and alert that the work is done.           
         resultq.put(mdict)
         q.task_done()
-    return 
 
-def joinable_queue(res,cores): 
+def joinable_queue(res,cores):
     
     t1 = time.time()
     #cores = mp.cpu_count()
@@ -104,26 +103,27 @@ def joinable_queue(res,cores):
         for key, value in d.items():
             for v in value:
                 ddict[key].add(v)
+
     for job in jobs:
         job.join()
     for job in jobs:
-        job.join()        
+        job.join()
     t2 = time.time()
     return (t2 - t1)
 
 if __name__ == "__main__":
 
     cores = int(sys.argv[1])
-    print "This version uses a joinable processing queue and {} cores.".format(cores)
+    print "This version uses a joinable processing queue and {0} cores.".format(cores)
     
     fnames = ['1024_lattice.shp', '10000_lattice.shp', '50176_lattice.shp', '100489_lattice.shp', '1000_poly.shp', '10000_poly.shp', '50000_poly.shp', '100000_poly.shp']
     
     for fname in fnames:
         res = bin_shapefile('TestData/'+fname)
         global shapes
-        global potential_neighbors 
+        global potential_neighbors
         shapes = res['shapes']
-        potential_neighbors = res['potential_neighbors']   
+        potential_neighbors = res['potential_neighbors']
         t = joinable_queue(res,cores)
         
-        print "{} required {} seconds.".format(fname, t)
+        print "{0} required {1} seconds.".format(fname, t)

--- a/weights/contiguity_managed_dict.py
+++ b/weights/contiguity_managed_dict.py
@@ -92,7 +92,7 @@ def managed_dict(res,cores):
 if __name__ == "__main__":
 
     cores = int(sys.argv[1])
-    print "This version uses a managed dictionary using {} cores.".format(cores)
+    print "This version uses a managed dictionary using {0} cores.".format(cores)
     
     fnames = ['1024_lattice.shp', '10000_lattice.shp', '50176_lattice.shp', '100489_lattice.shp', '1000_poly.shp', '10000_poly.shp', '50000_poly.shp', '100000_poly.shp']
     
@@ -105,4 +105,4 @@ if __name__ == "__main__":
         
         t = managed_dict(res,cores)
         
-        print "{} required {} seconds.".format(fname, t)
+        print "{0} required {1} seconds.".format(fname, t)

--- a/weights/contiguity_map_async.py
+++ b/weights/contiguity_map_async.py
@@ -98,7 +98,7 @@ def pool_map(res,cores):
 if __name__ == "__main__":
 
     cores = int(sys.argv[1])
-    print "This version uses map_async with a callback function and {} cores.".format(cores)
+    print "This version uses map_async with a callback function and {0} cores.".format(cores)
 
     fnames = ['1024_lattice.shp', '10000_lattice.shp', '50176_lattice.shp', '100489_lattice.shp', '1000_poly.shp', '10000_poly.shp', '50000_poly.shp', '100000_poly.shp']
     
@@ -111,4 +111,4 @@ if __name__ == "__main__":
         
         t = pool_map(res,cores)
         
-        print "{} required {} seconds.".format(fname, t)
+        print "{0} required {1} seconds.".format(fname, t)

--- a/weights/contiguity_serial.py
+++ b/weights/contiguity_serial.py
@@ -77,4 +77,4 @@ if __name__ == "__main__":
         
         t = check_joins()
         
-        print "{} required {} seconds.".format(fname, t)
+        print "{0} required {1} seconds.".format(fname, t)

--- a/weights/contiguity_time_tester.sh
+++ b/weights/contiguity_time_tester.sh
@@ -6,7 +6,7 @@ for c in 2 4 8 16 32
         python contiguity_joinable_queue.py $c
         python contiguity_managed_dict.py $c
         python contiguity_map_async.py $c
-
     done
+
 python contiguity_serial.py
 

--- a/weights/neighbors.py
+++ b/weights/neighbors.py
@@ -10,13 +10,15 @@ driver = ogr.GetDriverByName("ESRI Shapefile")
 output_shapefiles = []
 sizes = [100]
 for size in sizes:
-    output = "{}x{}.shp".format(size, size)
-    output_shapefiles.append("{}x{}.shp".format(size, size))
+    output = "{0}x{0}.shp".format(size)
+    output_shapefiles.append("{0}x{0}.shp".format(size))
     if os.path.exists(output): 
         driver.DeleteDataSource(output)
     datasource = driver.CreateDataSource(output)
+
     if datasource is None:
         print "Could not create file."
+
     layer = datasource.CreateLayer(output, geom_type=ogr.wkbPolygon)
 
     #Create all the fields

--- a/weights/parallel_contiguity_tests.py
+++ b/weights/parallel_contiguity_tests.py
@@ -346,8 +346,8 @@ def joinable_queue(res,w):
     for job in jobs:
         job.join()        
      
-    print "Joinable Queue Time: {}".format(t8-t6)
-    print "Are the results the same? {}".format(ddict == w)   
+    print "Joinable Queue Time: {0}".format(t8-t6)
+    print "Are the results the same? {0}".format(ddict == w)   
 
 def managed_dict(res, w):
     
@@ -453,8 +453,8 @@ def managed_dict(res, w):
     for job in jobs:
         job.join()
     t2 = time.time()
-    print "Managed Dict Time: {}".format(t2-t1)
-    print "Are the results the same? {}".format(mdict == w)
+    print "Managed Dict Time: {0}".format(t2-t1)
+    print "Are the results the same? {0}".format(mdict == w)
     
 def pcheck_joina(polygon_ids, potential_neighbors, shapes, weight_type='ROOK'):
 
@@ -563,8 +563,8 @@ def async_apply_w_callback(res,w):
     pool.join()
     
     t2 = time.time()
-    print "Async Apply Time: {}".format(t2-t1)
-    print "Are the results the same? {}".format(ddict == w)
+    print "Async Apply Time: {0}".format(t2-t1)
+    print "Are the results the same? {0}".format(ddict == w)
 
 def check_joinb(iterable, weight_type='ROOK'):
     polygon_ids = iterable[0]
@@ -661,7 +661,7 @@ def pool_map(res, w):
     results = [pool.map(check_joinb, iterable)]
  
     t10 = time.time()
-    print "Map Required: {}".format(t10-t9)
+    print "Map Required: {0}".format(t10-t9)
     
     
 if __name__ == "__main__":


### PR DESCRIPTION
Many machines still use python 2.6, which doesn't support zero length fields in string.format()
